### PR TITLE
Fix Build On MacOS Catalina and Swift 5

### DIFF
--- a/Example/AmazonFreeRTOSDemo/Podfile
+++ b/Example/AmazonFreeRTOSDemo/Podfile
@@ -1,7 +1,6 @@
 platform :ios, '11.0'
-#use_frameworks!
+use_frameworks!
 target 'AmazonFreeRTOSDemo' do
-  use_modular_headers!
   pod 'Alertift'
   pod 'AmazonFreeRTOS', :path => '../../'
   pod 'AWSAuthUI'


### PR DESCRIPTION
Based on https://github.com/aws-amplify/aws-sdk-ios/issues/2818

Changes pods to use_frameworks! instead of use_modular_headers!

Note: May need to update Podfile lock, will check tomorrow.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
