### PR TITLE
Add error notification callback in demo for wifi provisioning

### DIFF
--- a/Example/AmazonFreeRTOSDemo/AmazonFreeRTOSDemo/Examples/NetworkConfigViewController.swift
+++ b/Example/AmazonFreeRTOSDemo/AmazonFreeRTOSDemo/Examples/NetworkConfigViewController.swift
@@ -18,9 +18,9 @@ class NetworkConfigViewController: UITableViewController {
         // ListNetwork returned one network
         NotificationCenter.default.addObserver(self, selector: #selector(didListNetwork), name: .afrDidListNetwork, object: nil)
         // Refresh list on network operations
-        NotificationCenter.default.addObserver(self, selector: #selector(didOpNetwork), name: .afrDidSaveNetwork, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(didOpNetwork), name: .afrDidEditNetwork, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(didOpNetwork), name: .afrDidDeleteNetwork, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didSaveNetwork), name: .afrDidSaveNetwork, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didEditNetwork), name: .afrDidEditNetwork, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didDeleteNetwork), name: .afrDidDeleteNetwork, object: nil)
 
         refreshControl?.addTarget(self, action: #selector(didOpNetwork), for: .valueChanged)
 
@@ -52,6 +52,45 @@ extension NetworkConfigViewController {
         UIView.performWithoutAnimation {
             self.tableView.reloadData()
         }
+    }
+
+    @objc
+    func didSaveNetwork(_ notification: Notification) {
+        if let saveNetworkResp = notification.userInfo?["saveNetworkResp"] as? SaveNetworkResp {
+            if saveNetworkResp.status != NetworkOpStatus.success {
+                Alertift.alert(title: NSLocalizedString("Error", comment: String()), message: NSLocalizedString("Failed to save the WiFi network with status: \(saveNetworkResp.status)", comment: String()))
+                    .action(.default(NSLocalizedString("OK", comment: String())))
+                    .show(on: self)
+            }
+        }
+
+        didOpNetwork()
+    }
+
+    @objc
+    func didEditNetwork(_ notification: Notification) {
+        if let editNetworkResp = notification.userInfo?["editNetworkResp"] as? EditNetworkResp {
+            if editNetworkResp.status != NetworkOpStatus.success {
+                Alertift.alert(title: NSLocalizedString("Error", comment: String()), message: NSLocalizedString("Failed to save the WiFi network with status: \(editNetworkResp.status)", comment: String()))
+                    .action(.default(NSLocalizedString("OK", comment: String())))
+                    .show(on: self)
+            }
+        }
+
+        didOpNetwork()
+    }
+
+    @objc
+    func didDeleteNetwork(_ notification: Notification) {
+        if let deleteNetworkResp = notification.userInfo?["deleteNetworkResp"] as? DeleteNetworkResp {
+            if deleteNetworkResp.status != NetworkOpStatus.success {
+                Alertift.alert(title: NSLocalizedString("Error", comment: String()), message: NSLocalizedString("Failed to save the WiFi network with status: \(deleteNetworkResp.status)", comment: String()))
+                    .action(.default(NSLocalizedString("OK", comment: String())))
+                    .show(on: self)
+            }
+        }
+
+        didOpNetwork()
     }
 
     @objc


### PR DESCRIPTION
*Issue #, if available:*
Issue #17 

*Description of changes:*
This change shows in demo how to retrieve the save, edit and delete network operation status from SDK and display it to the user.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
