### PR TITLE
Fix: Xcode 13, Swift 5.5 Support

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -2,3 +2,4 @@
 --decimalgrouping ignore
 --disable blankLinesAtStartOfScope
 --enable isEmpty
+--extensionacl on-declarations

--- a/AmazonFreeRTOS/AmazonFreeRTOSManager.swift
+++ b/AmazonFreeRTOS/AmazonFreeRTOSManager.swift
@@ -25,7 +25,7 @@ public class AmazonFreeRTOSManager: NSObject {
     /// Initializes a new FreeRTOS manager.
     ///
     /// - Returns: A new FreeRTOS manager.
-    public override init() {
+    override public init() {
         super.init()
         central = CBCentralManager(delegate: self, queue: nil, options: [CBCentralManagerOptionShowPowerAlertKey: true])
     }

--- a/AmazonFreeRTOS/Extensions/NSNotification.Name+AmazonFreeRTOS.swift
+++ b/AmazonFreeRTOS/Extensions/NSNotification.Name+AmazonFreeRTOS.swift
@@ -4,44 +4,44 @@ extension NSNotification.Name {
     // BLE Central
 
     /// FreeRTOS BLE Central Manager didUpdateState.
-    public static let afrCentralManagerDidUpdateState: NSNotification.Name = NSNotification.Name("afrCentralManagerDidUpdateState")
+    public static let afrCentralManagerDidUpdateState = NSNotification.Name("afrCentralManagerDidUpdateState")
     /// FreeRTOS BLE Central Manager didDiscoverDevice.
-    public static let afrCentralManagerDidDiscoverDevice: NSNotification.Name = NSNotification.Name("afrCentralManagerDidDiscoverDevice")
+    public static let afrCentralManagerDidDiscoverDevice = NSNotification.Name("afrCentralManagerDidDiscoverDevice")
     /// FreeRTOS BLE Central Manager didConnectDevice.
-    public static let afrCentralManagerDidConnectDevice: NSNotification.Name = NSNotification.Name("afrCentralManagerDidConnectDevice")
+    public static let afrCentralManagerDidConnectDevice = NSNotification.Name("afrCentralManagerDidConnectDevice")
     /// FreeRTOS BLE Central Manager didDisconnectDevice.
-    public static let afrCentralManagerDidDisconnectDevice: NSNotification.Name = NSNotification.Name("afrCentralManagerDidDisconnectDevice")
+    public static let afrCentralManagerDidDisconnectDevice = NSNotification.Name("afrCentralManagerDidDisconnectDevice")
     /// FreeRTOS BLE Central Manager didFailToConnectDevice.
-    public static let afrCentralManagerDidFailToConnectDevice: NSNotification.Name = NSNotification.Name("afrCentralManagerDidFailToConnectDevice")
+    public static let afrCentralManagerDidFailToConnectDevice = NSNotification.Name("afrCentralManagerDidFailToConnectDevice")
 
     // BLE Peripheral
 
     /// FreeRTOS BLE Peripheral didDiscoverServices.
-    public static let afrPeripheralDidDiscoverServices: NSNotification.Name = NSNotification.Name("afrPeripheralDidDiscoverServices")
+    public static let afrPeripheralDidDiscoverServices = NSNotification.Name("afrPeripheralDidDiscoverServices")
     /// FreeRTOS BLE Peripheral didDiscoverCharacteristics.
-    public static let afrPeripheralDidDiscoverCharacteristics: NSNotification.Name = NSNotification.Name("afrPeripheralDidDiscoverCharacteristics")
+    public static let afrPeripheralDidDiscoverCharacteristics = NSNotification.Name("afrPeripheralDidDiscoverCharacteristics")
 
     // DeviceInfo
 
     /// FreeRTOS return device info afr version.
-    public static let afrDeviceInfoAfrVersion: NSNotification.Name = NSNotification.Name("afrDeviceInfoAfrVersion")
+    public static let afrDeviceInfoAfrVersion = NSNotification.Name("afrDeviceInfoAfrVersion")
     /// FreeRTOS return device info broker endpoint.
-    public static let afrDeviceInfoBrokerEndpoint: NSNotification.Name = NSNotification.Name("afrDeviceInfoBrokerEndpoint")
+    public static let afrDeviceInfoBrokerEndpoint = NSNotification.Name("afrDeviceInfoBrokerEndpoint")
     /// FreeRTOS return device info mtu.
-    public static let afrDeviceInfoMtu: NSNotification.Name = NSNotification.Name("afrDeviceInfoMtu")
+    public static let afrDeviceInfoMtu = NSNotification.Name("afrDeviceInfoMtu")
     /// FreeRTOS return device info afr platform.
-    public static let afrDeviceInfoAfrPlatform: NSNotification.Name = NSNotification.Name("afrDeviceInfoAfrPlatform")
+    public static let afrDeviceInfoAfrPlatform = NSNotification.Name("afrDeviceInfoAfrPlatform")
     /// FreeRTOS return device info afr dev id.
-    public static let afrDeviceInfoAfrDevId: NSNotification.Name = NSNotification.Name("afrDeviceInfoAfrDevId")
+    public static let afrDeviceInfoAfrDevId = NSNotification.Name("afrDeviceInfoAfrDevId")
 
     // NetworkConfig
 
     /// FreeRTOS list network returned a saved or scaned network.
-    public static let afrDidListNetwork: NSNotification.Name = NSNotification.Name("afrDidListNetwork")
+    public static let afrDidListNetwork = NSNotification.Name("afrDidListNetwork")
     /// FreeRTOS save network did save a network.
-    public static let afrDidSaveNetwork: NSNotification.Name = NSNotification.Name("afrDidSaveNetwork")
+    public static let afrDidSaveNetwork = NSNotification.Name("afrDidSaveNetwork")
     /// FreeRTOS edit network did edit a saved network.
-    public static let afrDidEditNetwork: NSNotification.Name = NSNotification.Name("afrDidEditNetwork")
+    public static let afrDidEditNetwork = NSNotification.Name("afrDidEditNetwork")
     /// FreeRTOS delete network did delete a saved network.
-    public static let afrDidDeleteNetwork: NSNotification.Name = NSNotification.Name("afrDidDeleteNetwork")
+    public static let afrDidDeleteNetwork = NSNotification.Name("afrDidDeleteNetwork")
 }

--- a/Example/AmazonFreeRTOSDemo/AmazonFreeRTOSDemo/DevicesViewController.swift
+++ b/Example/AmazonFreeRTOSDemo/AmazonFreeRTOSDemo/DevicesViewController.swift
@@ -159,7 +159,6 @@ extension DevicesViewController {
                         Alertift.alert(title: NSLocalizedString("Error", comment: String()), message: error.localizedDescription)
                             .action(.default(NSLocalizedString("OK", comment: String())))
                             .show(on: self)
-                        return
                     }
                 }
             })
@@ -213,21 +212,18 @@ extension DevicesViewController {
 
                     .action(.default(NSLocalizedString("MQTT Proxy", comment: String()))) { _, _ in
                         self.performSegue(withIdentifier: "toMqttProxyViewController", sender: self)
-                        return
                     }
 
                     // Example 2: Network Config
 
                     .action(.default(NSLocalizedString("Network Config", comment: String()))) { _, _ in
                         self.performSegue(withIdentifier: "toNetworkConfigViewController", sender: self)
-                        return
                     }
 
                     // Example 3: Custom GATT MQTT
 
                     .action(.default(NSLocalizedString("Custom GATT MQTT", comment: String()))) { _, _ in
                         self.performSegue(withIdentifier: "toCustomGattMqttViewController", sender: self)
-                        return
                     }
                     .action(.cancel(NSLocalizedString("Cancel", comment: String())))
                     .show(on: self)


### PR DESCRIPTION
*Description of changes:*
Resolves isses stemming from the latest XCode 13 that contains Swift 5.5; instead of warnings the following have become errors and therefore using the latest xcode with swift 5.5 one can no longer compile the library.  In order to resolve this the following errors were resolved:

* No Extension Access Modifier Violation: Prefer not to use extension access modifiers
* Value of optional type CBService? must be unwrapped to refer to member uuid of wrapped base type CBService

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
