### PR TITLE
wifi provisioning: Add error notifications and end of WiFi list marker

### DIFF
--- a/AmazonFreeRTOS/AmazonFreeRTOSManager.swift
+++ b/AmazonFreeRTOS/AmazonFreeRTOSManager.swift
@@ -98,21 +98,24 @@ extension AmazonFreeRTOSManager: CBCentralManagerDelegate {
         if devices[peripheral.identifier]?.reconnect ?? false {
             central.connect(peripheral, options: nil)
         }
-        NotificationCenter.default.post(name: .afrCentralManagerDidDisconnectDevice, object: nil, userInfo: ["identifier": peripheral.identifier])
+
         if let error = error {
             debugPrint("[\(peripheral.identifier.uuidString)][ERROR] afrCentralManagerDidDisconnectPeripheral: \(error.localizedDescription)")
+            NotificationCenter.default.post(name: .afrCentralManagerDidDisconnectDevice, object: nil, userInfo: ["identifier": peripheral.identifier, "error": error])
             return
         }
+        NotificationCenter.default.post(name: .afrCentralManagerDidDisconnectDevice, object: nil, userInfo: ["identifier": peripheral.identifier])
         debugPrint("[\(peripheral.identifier.uuidString)] afrCentralManagerDidDisconnectPeripheral")
     }
 
     /// CBCentralManagerDelegate
     public func centralManager(_: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
-        NotificationCenter.default.post(name: .afrCentralManagerDidFailToConnectDevice, object: nil, userInfo: ["identifier": peripheral.identifier])
         if let error = error {
             debugPrint("[\(peripheral.identifier.uuidString)][ERROR] afrCentralManagerDidFailToConnectPeripheral: \(error.localizedDescription)")
+            NotificationCenter.default.post(name: .afrCentralManagerDidFailToConnectDevice, object: nil, userInfo: ["identifier": peripheral.identifier, "error": error])
             return
         }
+        NotificationCenter.default.post(name: .afrCentralManagerDidFailToConnectDevice, object: nil, userInfo: ["identifier": peripheral.identifier])
         debugPrint("[\(peripheral.identifier.uuidString)] afrCentralManagerDidFailToConnectPeripheral")
     }
 }

--- a/AmazonFreeRTOS/Services/NetworkConfig/ListNetworkResp.swift
+++ b/AmazonFreeRTOS/Services/NetworkConfig/ListNetworkResp.swift
@@ -18,6 +18,8 @@ public struct ListNetworkResp: Decodable {
     public var hidden: Bool
     /// Wifi is connected or not.
     public var connected: Bool
+    /// Last Network in the list or not
+    public var last: Bool?
 
     private enum CodingKeys: String, CodingKey {
         case index = "g"
@@ -28,5 +30,6 @@ public struct ListNetworkResp: Decodable {
         case security = "q"
         case hidden = "f"
         case connected = "e"
+        case last = "l"
     }
 }

--- a/Example/AmazonFreeRTOSDemo/AmazonFreeRTOSDemo/DevicesViewController.swift
+++ b/Example/AmazonFreeRTOSDemo/AmazonFreeRTOSDemo/DevicesViewController.swift
@@ -20,7 +20,7 @@ class DevicesViewController: UITableViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(centralManagerDidDisconnectDevice), name: .afrCentralManagerDidDisconnectDevice, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(reloadDataWithoutAnimation), name: .afrCentralManagerDidDiscoverDevice, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(reloadDataWithoutAnimation), name: .afrCentralManagerDidConnectDevice, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(reloadDataWithoutAnimation), name: .afrCentralManagerDidFailToConnectDevice, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(centralManagerDidFailToConnectToDevice), name: .afrCentralManagerDidFailToConnectDevice, object: nil)
 
         centralManagerDidUpdateState()
         #warning("remove showLogin() if you do not plan to use the MQTT demo")
@@ -65,6 +65,17 @@ extension DevicesViewController {
         if notification.userInfo?["identifier"] as? UUID == uuid {
             _ = navigationController?.popToRootViewController(animated: true)
         }
+    }
+
+    // Alert user on connect failure
+    @objc
+    func centralManagerDidFailToConnectToDevice(_ notification: Notification) {
+        if let error = notification.userInfo?["error"] as? Error {
+            Alertift.alert(title: NSLocalizedString("Error", comment: String()), message: NSLocalizedString("Failed to connect to peripheral with error: \(error.localizedDescription)", comment: String()))
+                .action(.default(NSLocalizedString("OK", comment: String())))
+                .show(on: self)
+        }
+        reloadDataWithoutAnimation()
     }
 
     @objc


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
* Propagate errors on connect failures, from the SDK. Add notification from SDK. Demo app subscribes to notification and alerts user with the error.
* Add end of list WiFi marker to know the scanned/saved networks are complete. This is a backwards compatible change and follows PR: https://github.com/aws/amazon-freertos/pull/3489

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
